### PR TITLE
Supported scheme on custom dom-element

### DIFF
--- a/build/tasks/generate_scheme.js
+++ b/build/tasks/generate_scheme.js
@@ -54,7 +54,7 @@ function generateScheme(scheme, palette, defaultSchemeId, targetDir) {
   for (const schemeId in scheme) {
     const clusters = scheme[schemeId].colors;
     let css = '/* stylelint-disable */\n/*\n* Этот файл сгенерирован автоматически. Не надо править его руками.\n*/\n';
-    css += schemeId === defaultSchemeId ? ':root {\n' : `[scheme="${schemeId}"] {\n`;
+    css += schemeId === defaultSchemeId ? ':root {\n' : `body[scheme="${schemeId}"], [scheme="${schemeId}"] {\n`;
     Object.keys(clusters).sort((a, b) => a.localeCompare(b)).forEach((clusterId) => {
       css += `  --${clusterId}: ${resolveColor(palette, clusters[clusterId]).toLowerCase()};\n`;
     });

--- a/build/tasks/generate_scheme.js
+++ b/build/tasks/generate_scheme.js
@@ -54,7 +54,7 @@ function generateScheme(scheme, palette, defaultSchemeId, targetDir) {
   for (const schemeId in scheme) {
     const clusters = scheme[schemeId].colors;
     let css = '/* stylelint-disable */\n/*\n* Этот файл сгенерирован автоматически. Не надо править его руками.\n*/\n';
-    css += schemeId === defaultSchemeId ? ':root {\n' : `body[scheme="${schemeId}"] {\n`;
+    css += schemeId === defaultSchemeId ? ':root {\n' : `[scheme="${schemeId}"] {\n`;
     Object.keys(clusters).sort((a, b) => a.localeCompare(b)).forEach((clusterId) => {
       css += `  --${clusterId}: ${resolveColor(palette, clusters[clusterId]).toLowerCase()};\n`;
     });


### PR DESCRIPTION
Пока это нужно только для документации. Там в скором времени появятся примеры, которые рендерятся без айфрейма. Хочется, чтобы они меняли атрибут scheme не на body документации, а на дом-ноде, в которой они рисуются.