### PR TITLE
feat(HTMLEntities): add Replacer

### DIFF
--- a/src/html/__tests__/htmlEntities.test.js
+++ b/src/html/__tests__/htmlEntities.test.js
@@ -7,7 +7,7 @@ import {
   decodeHTMLEntities,
   outOfBoundsChar,
   decodeHTMLEntitiesDeep,
-} from '../htmlEntities';
+} from '../escape';
 
 const empty = [
   [
@@ -84,7 +84,7 @@ const decodeTests = [
   ],
   [
     '&#34 &#34;',
-    `&#34 "`,
+    `" "`,
   ],
   [
     'Привет&#33;',
@@ -101,7 +101,7 @@ const decodeTests = [
   [
     'a\n&#60;&#62;&#34;&#39;&#38;&#169;&#8710;&#8478;&#128514;\x00&#1;',
     'a\n<>"\'&©∆℞😂\0\x01',
-  ]
+  ],
 ];
 
 test.each(decodeTests)('decodeHTMLEntities(%j) should equal %j', (input, expected) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ export {
   encodeHTMLEntities,
   decodeHTMLEntities,
   decodeHTMLEntitiesDeep,
-} from './htmlEntities';
+} from './html/escape';
 
 export { leadingZero, formatNumber } from './numbers';
 

--- a/src/lib/replacer.ts
+++ b/src/lib/replacer.ts
@@ -1,0 +1,33 @@
+import { escapeRegExp } from '../regexp';
+
+export class Replacer {
+  private regexp: RegExp | undefined;
+  private map: Record<string, string>;
+
+  constructor(map: Record<string, string>) {
+    this.map = map;
+  }
+
+  private build() {
+    if (this.regexp) {
+      return;
+    }
+
+    const groups = Object.keys(this.map)
+      .map(escapeRegExp)
+      .sort((a, b) => b.length - a.length);
+    const pattern = `(?:${groups.join('|')})`;
+
+    this.regexp = new RegExp(pattern, 'g');
+  }
+
+  replace(string: string) {
+    if (!string) {
+      return '';
+    }
+
+    this.build();
+
+    return string.replace(this.regexp!, (substring) => this.map[substring]);
+  }
+}


### PR DESCRIPTION
- Переделал HTMLEntities на использование `Replacer`-а
- Исправил проблему с `;`

> Note. In SGML, it is possible to eliminate the final ";" after a character reference in some cases (e.g., at a line break or immediately before a tag). In other circumstances it may not be eliminated (e.g., in the middle of a word). We strongly suggest using the ";" in all cases to avoid problems with user agents that require this character to be present.

[5.3 Character references](https://www.w3.org/TR/1999/REC-html401-19991224/charset.html#entities)

Поэтому браузер превращает `&#34` в `"`