### PR TITLE
tech(infra): fix ESLint and Jest configs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -53,7 +53,9 @@
 
         "@typescript-eslint/indent": "off",
         "@typescript-eslint/no-extra-parens": "off",
-        "space-before-function-paren": "off"
+        "space-before-function-paren": "off",
+
+        "spaced-comment": ["error", "always", { "exceptions": ["#__PURE__"] }]
       }
     }
   ]

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,8 @@
 module.exports = {
   presets: ['@babel/preset-env', '@babel/preset-typescript'],
-  plugins: ['@babel/plugin-proposal-class-properties', '@babel/plugin-proposal-object-rest-spread', '@babel/plugin-transform-runtime'],
+  plugins: [
+    '@babel/plugin-proposal-class-properties',
+    '@babel/plugin-proposal-object-rest-spread',
+    '@babel/plugin-transform-runtime',
+  ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,6 @@
+const path = require('path');
+
 module.exports = {
   testEnvironment: 'jsdom',
+  roots: [path.join(__dirname, 'src')],
 };


### PR DESCRIPTION
- Правило `spaced-comment` ESLint'а ругалось на `/*#__PURE__*/` – добавил в ислкючение.
- Jest конфиг искал файлы в корне конфига, из-за чего Jest падали если собран `lib/` (см. *) – добавил в конфиг, чтобы Jest искал тесты в `src/`.
  > \* это "бага", что в `lib/` попадает папка `__tests__/`.
  > Поправил здесь https://github.com/VKCOM/vkjs/pull/113#issuecomment-1367381419
- Применил Prettier к `babel.config.js`.