### PR TITLE
ci: update setup-node@v3

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,9 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
+          cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: yarn test
 


### PR DESCRIPTION
> **Warning**
> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-node@v1.