### PR TITLE
fix: improve clipboard fallback fn usage

### DIFF
--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -47,7 +47,7 @@ function copyWithFakeElement(text: string): Promise<boolean> {
 
 export function copyTextToClipboard(text: string): Promise<boolean> {
   if (navigator.clipboard) {
-    return copyWithNavigator(text);
+    return copyWithNavigator(text).catch(() => copyWithFakeElement(text));
   } else {
     return copyWithFakeElement(text);
   }


### PR DESCRIPTION
Столкнулся  с проблемой, что не вызывается fallback копирование, если не получилось скопировать через navigator.clipboard.

