### PR TITLE
Add declarationMap to tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "preserveConstEnums": true,
     "strictNullChecks": true,
     "declaration": true,
+    "declarationMap": true,
     "declarationDir": "lib",
     "sourceMap": false,
     "baseUrl": "src"


### PR DESCRIPTION
Сейчас если использовать навигацию по коду с целью посмотреть код функции, будешь попадать просто в `.d.ts` файл. Это крайне неудобно, потому что потом приходится руками искать уже файл с кодом.

Этот параметр должен пофиксить проблему.