### PR TITLE
fix(package.json): add default field to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "2.0.0",
   "description": "VK shared JS libs",
   "type": "module",
-  "main": "lib/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
-      "import": "./lib/index.js"
+      "import": "./lib/index.js",
+      "default": "./lib/index.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
- caused by #552

----

При запуске **ESLint** с расширением `*.cjs` (`.eslintrc.cjs`), скрипт пытается зарезолвить модули как commonjs, поэтому в "exports" ищет поля `require` или `default`. Т.к. `require` нам не подходит, т.к. с **v2.0.0** перешли на **ESM**, то указываем `default` дублирующий по значению `import` (см. https://github.com/octokit/core.js/issues/667#issuecomment-2037592361)

Также удалил уже не актуальное поле `"main"`.