### PR TITLE
ci(codecov): use_oidc

### DIFF
--- a/.github/workflows/reusable_workflow_test.yml
+++ b/.github/workflows/reusable_workflow_test.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     name: Run unit tests
     steps:
@@ -29,4 +31,4 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true


### PR DESCRIPTION
Используем [oidc](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect) подпись вместо токена для codecov