### PR TITLE
ci(dependabot): rm reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,8 +28,6 @@ updates:
         patterns:
           - 'prettier'
           - '@vkontakte/prettier-config'
-    reviewers:
-      - 'VKCOM/vk-sec'
 
   - package-ecosystem: 'github-actions'
     # Workflow files stored in the
@@ -37,5 +35,3 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    reviewers:
-      - 'VKCOM/vk-sec'


### PR DESCRIPTION
GitHub удаляет поле reviewers так как оно дублируется кодовнерством

https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/