### PR TITLE
Optimized format number

### DIFF
--- a/src/other/numbers.test.ts
+++ b/src/other/numbers.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from '@jest/globals';
 import { formatNumber } from './numbers';
 
 describe('formatNumber', () => {
-  const cases: [number, string][] = [
+  const cases: Array<[number, string]> = [
     [0, '0'],
     [1, '1'],
     [1000, '1 000'],
@@ -11,13 +11,13 @@ describe('formatNumber', () => {
     [1000000.001, '1 000 000,001'],
     [9000009.999, '9 000 009,999'],
     [999.999, '999,999'],
-    [1999.100, '1 999,1'],
-    [-1999.100, '-1 999,1'],
+    [1999.1, '1 999,1'],
+    [-1999.1, '-1 999,1'],
   ];
 
   cases.forEach(([input, result]) => {
     test(`should format ${input} to ${result}`, () => {
       expect(formatNumber(input)).toBe(result);
-    })
+    });
   });
 });

--- a/src/other/numbers.test.ts
+++ b/src/other/numbers.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { formatNumber } from './numbers';
+
+describe('formatNumber', () => {
+  const cases: [number, string][] = [
+    [0, '0'],
+    [1, '1'],
+    [1000, '1 000'],
+    [1000.1, '1 000,1'],
+    [1000000.001, '1 000 000,001'],
+    [9000009.999, '9 000 009,999'],
+    [999.999, '999,999'],
+    [1999.100, '1 999,1'],
+    [-1999.100, '-1 999,1'],
+  ];
+
+  cases.forEach(([input, result]) => {
+    test(`should format ${input} to ${result}`, () => {
+      expect(formatNumber(input)).toBe(result);
+    })
+  });
+});

--- a/src/other/numbers.test.ts
+++ b/src/other/numbers.test.ts
@@ -13,11 +13,17 @@ describe('formatNumber', () => {
     [999.999, '999,999'],
     [1999.1, '1 999,1'],
     [-1999.1, '-1 999,1'],
+    [-331999.1000001, '-331 999,1000001'],
   ];
 
   cases.forEach(([input, result]) => {
     test(`should format ${input} to ${result}`, () => {
       expect(formatNumber(input)).toBe(result);
     });
+  });
+
+  // Alternative separator
+  test(`should format -331999.1000001 to -331_999|1000001`, () => {
+    expect(formatNumber(-331999.1000001, '_', '|')).toBe('-331_999|1000001');
   });
 });

--- a/src/other/numbers.ts
+++ b/src/other/numbers.ts
@@ -13,13 +13,8 @@ export function leadingZero(number: number): string {
  * Форматирует число, разбивая его на разряды
  */
 export function formatNumber(number: number, separator = ' ', decimalSeparator = ','): string {
-  const numberParts = number.toString().split('.');
-  const result = [];
+  const formatedInt = (number | 0).toLocaleString('en-US').replace(/,/g, separator);
+  const floatPart = String(number).split('.')[1];
 
-  for (let i = numberParts[0].length - 3; i > -3; i -= 3) {
-    result.unshift(numberParts[0].slice(i > 0 ? i : 0, i + 3));
-  }
-
-  numberParts[0] = result.join(separator);
-  return numberParts.join(decimalSeparator);
+  return floatPart ? `${formatedInt}${decimalSeparator}${floatPart}` : formatedInt;
 }


### PR DESCRIPTION
Исправил не корректный формат у отрицательных чисел, когда `-331999` форматируется как `- 331 999`. Так же оптимизировал алгоритм, путем избежания лишних массивов, slice, unshift.
Перед этим добавил тест, чтобы убедиться, что не сломал ничего.